### PR TITLE
Integrate changes from https://github.com/datasift/gitflow

### DIFF
--- a/hubflow-common
+++ b/hubflow-common
@@ -354,7 +354,7 @@ hubflow_local_merge_helper() {
 }
 
 hubflow_fetch_latest_changes_from_origin() {
-    git remote update || die "Unable to get list of latest changes from '$ORIGIN'"
+    git remote update "$ORIGIN" || die "Unable to get list of latest changes from '$ORIGIN'"
     git fetch "$ORIGIN" || die "Unable to fetch latest changes from '$ORIGIN'"
     git fetch --tags  || die "Unable to fetch latest tags from '$ORIGIN'"
 }

--- a/hubflow-common
+++ b/hubflow-common
@@ -44,7 +44,7 @@
 # Common variables
 #
 
-HUBFLOW_VERSION=1.5.3
+HUBFLOW_VERSION=1.5.4
 HUBFLOW_REPO=https://github.com/TargetProcess/gitflow
 
 #
@@ -246,9 +246,10 @@ hubflow_branch_pop() {
     [[ $BRANCH_STACK_SP != 0 ]] || die "Internal error: attempt to pop from empty BRANCH_STACK"
 
     # pop the branch from the stack
-    local popped_branch=${BRANCH_STACK[$BRANCH_STACK_SP]}
-    BRANCH_STACK[$BRANCH_STACK_SP]=
+    local tmp_branch_sp=$BRANCH_STACK_SP
     let "BRANCH_STACK_SP -= 1"
+    local popped_branch=${BRANCH_STACK[$BRANCH_STACK_SP]}
+    unset BRANCH_STACK[$tmp_branch_sp]
 
     # do we need to switch branch too?
     hubflow_change_branch "$popped_branch"

--- a/hubflow-common
+++ b/hubflow-common
@@ -263,7 +263,7 @@ hubflow_branch_pop_no_checkout() {
     [[ $BRANCH_STACK_SP != 0 ]] || die "Internal error: attempt to pop from empty BRANCH_STACK"
 
     # pop the branch from the stack
-    BRANCH_STACK[$BRANCH_STACK_SP]=
+    BRANCH_STACK[$BRANCH_STACK_SP-1]=
     let "BRANCH_STACK_SP -= 1"
 }
 


### PR DESCRIPTION
Integrate changes from https://github.com/datasift/gitflow to support git 2.16+,
since was the bug in branch stack mechanism and in 2.16+:
> Use of an empty string as a pathspec element that is used for  'everything matches' is now an error.

Also, fetch only origin latest changes.

See:
1. https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.0.txt
2. https://github.com/datasift/gitflow/commit/ed032438d2100b826d2fd5c8281b5e07d88ab9eb
3. https://github.com/TargetProcess/gitflow/commit/dc5cf2931c83795853bfcbac2dbe88093aa8da50
4. https://github.com/datasift/gitflow/commit/25987730e7bb370b9be8a9588b8def97876f1085
for details.